### PR TITLE
feat: add Python RL scoring to Simon plugin

### DIFF
--- a/pkg/simulator/plugin/rl_scheduler_score.go
+++ b/pkg/simulator/plugin/rl_scheduler_score.go
@@ -1,0 +1,117 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	simontype "github.com/hkust-adsl/kubernetes-scheduler-simulator/pkg/type"
+)
+
+// RLSchedulerScorePlugin queries an external RL service for node scores.
+type RLSchedulerScorePlugin struct {
+	handle   framework.Handle
+	client   *http.Client
+	endpoint string
+}
+
+var _ framework.ScorePlugin = &RLSchedulerScorePlugin{}
+var _ framework.PreScorePlugin = &RLSchedulerScorePlugin{}
+
+const rlScoreStateKey = "PreScore-RLSchedulerScorePlugin"
+
+// rlScoreState stores node scores returned by the RL service.
+type rlScoreState struct {
+	scores map[string]int64
+}
+
+// Clone implements the StateData interface.
+func (s *rlScoreState) Clone() framework.StateData { return s }
+
+// NewRLSchedulerScorePlugin initializes the plugin.
+func NewRLSchedulerScorePlugin(configuration runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+	endpoint := os.Getenv("RL_SCHEDULER_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:5000/score"
+	}
+	return &RLSchedulerScorePlugin{
+		handle:   handle,
+		client:   &http.Client{},
+		endpoint: endpoint,
+	}, nil
+}
+
+// Name returns the plugin name.
+func (p *RLSchedulerScorePlugin) Name() string {
+	return simontype.RLSchedulerScorePluginName
+}
+
+// rlRequest carries the scheduling context sent to the RL service.
+type rlRequest struct {
+	Pod   *corev1.Pod   `json:"pod"`
+	Nodes []corev1.Node `json:"nodes"`
+}
+
+// rlResponse captures scores from the RL service.
+type rlResponse struct {
+	Scores map[string]int64 `json:"scores"`
+}
+
+// PreScore calls the RL service once per scheduling cycle to obtain node scores.
+func (p *RLSchedulerScorePlugin) PreScore(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodes []*corev1.Node) *framework.Status {
+	req := rlRequest{Pod: pod.DeepCopy()}
+	for _, n := range nodes {
+		req.Nodes = append(req.Nodes, *n)
+	}
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return framework.AsStatus(err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return framework.AsStatus(err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return framework.AsStatus(err)
+	}
+	defer resp.Body.Close()
+
+	var r rlResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return framework.AsStatus(err)
+	}
+
+	state.Write(rlScoreStateKey, &rlScoreState{scores: r.Scores})
+	return nil
+}
+
+// Score returns the score for a given node from the RL service response.
+func (p *RLSchedulerScorePlugin) Score(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeName string) (int64, *framework.Status) {
+	c, err := state.Read(rlScoreStateKey)
+	if err != nil {
+		return 0, framework.AsStatus(fmt.Errorf("reading %q from cycleState: %w", rlScoreStateKey, err))
+	}
+	s, ok := c.(*rlScoreState)
+	if !ok {
+		return 0, framework.AsStatus(fmt.Errorf("cannot convert saved state to rlScoreState"))
+	}
+	if score, ok := s.scores[nodeName]; ok {
+		return score, framework.NewStatus(framework.Success)
+	}
+	return framework.MinNodeScore, framework.NewStatus(framework.Success)
+}
+
+// ScoreExtensions is not used.
+func (p *RLSchedulerScorePlugin) ScoreExtensions() framework.ScoreExtensions { return nil }

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -155,6 +155,9 @@ func New(opts ...Option) (Interface, error) {
 		simontype.FGDScorePluginName: func(configuration runtime.Object, handle framework.Handle) (framework.Plugin, error) {
 			return simonplugin.NewFGDScorePlugin(configuration, handle, &sim.typicalPods)
 		},
+		simontype.RLSchedulerScorePluginName: func(configuration runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+			return simonplugin.NewRLSchedulerScorePlugin(configuration, handle)
+		},
 	}
 	sim.scheduler, err = scheduler.New(
 		sim.client,

--- a/pkg/simulator/utils.go
+++ b/pkg/simulator/utils.go
@@ -235,6 +235,9 @@ func GetAndSetSchedulerConfig(schedulerConfig string) (*config.CompletedConfig, 
 			{
 				Name: simontype.RandomScorePluginName,
 			},
+			{
+				Name: simontype.RLSchedulerScorePluginName,
+			},
 		},
 	}
 	kcfg.Profiles[0].Plugins.Score = &kubeschedulerconfig.PluginSet{
@@ -253,6 +256,9 @@ func GetAndSetSchedulerConfig(schedulerConfig string) (*config.CompletedConfig, 
 			},
 			{
 				Name: simontype.FGDScorePluginName,
+			},
+			{
+				Name: simontype.RLSchedulerScorePluginName,
 			},
 		},
 	}

--- a/pkg/type/const.go
+++ b/pkg/type/const.go
@@ -10,6 +10,7 @@ const (
 	GpuPackingScorePluginName    = "GpuPackingScore"
 	BestFitScorePluginName       = "BestFitScore"
 	FGDScorePluginName           = "FGDScore"
+	RLSchedulerScorePluginName   = "RLSchedulerScore"
 
 	NewNodeNamePrefix    = "simon"
 	DefaultSchedulerName = "simon-scheduler"

--- a/scripts/generate_config_and_run.py
+++ b/scripts/generate_config_and_run.py
@@ -26,6 +26,7 @@ SCORE_POLICY_ABBR = {
     "GpuPackingScore":    "GpuPacking",
     "BestFitScore":       "BestFit",
     "FGDScore":           "FGD",
+    "RLSchedulerScore":  "RLSched",
 }
 
 SCORE_PLUGINS_WITH_DIM_NORM_GPU_METHOD = [
@@ -36,6 +37,7 @@ SCORE_PLUGINS_WITH_PRE_FILTER = [
 ]
 SCORE_PLUGINS_WITH_PRE_SCORE = [
     "RandomScore",
+    "RLSchedulerScore",
 ]
 
 def get_args():


### PR DESCRIPTION
## Summary
- send pod and node resources to an external Python RL service during the Score phase
- add helper structs and env-configurable endpoint for RL scoring

## Testing
- `go test ./...`
- `python -m py_compile scripts/generate_config_and_run.py` *(warns about existing invalid escape sequence)*

------
https://chatgpt.com/codex/tasks/task_e_689d42f510e483278ace2b5bad1bd629