### PR TITLE
Add PyTorch RL scheduler example configs

### DIFF
--- a/example/pytorch-rl/cluster_config.yaml
+++ b/example/pytorch-rl/cluster_config.yaml
@@ -1,0 +1,17 @@
+apiVersion: simon/v1alpha1
+kind: Config
+metadata:
+  name: pytorch-rl-config
+spec:
+  cluster:
+    customConfig: example/pytorch-rl
+  customConfig:
+    shufflePod: false
+    workloadTuningConfig:
+      ratio: 0.9
+      seed: 233
+    typicalPodsConfig:
+      isInvolvedCpuPods: true
+      podPopularityThreshold: 95
+      isConsideredGpuResWeight: false
+

--- a/example/pytorch-rl/node/pai-node-00.yaml
+++ b/example/pytorch-rl/node/pai-node-00.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Node
+metadata:
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: pai-node-00
+    kubernetes.io/os: linux
+    node-role.kubernetes.io/master: ''
+    alibabacloud.com/gpu-card-model: V100
+    node-ip: 192.168.0.100
+  name: pai-node-00
+status:
+  allocatable:
+    alibabacloud.com/gpu-count: '2'
+    alibabacloud.com/gpu-milli: '2000'
+    cpu: 64
+    memory: 256000Mi
+    pods: '110'
+  capacity:
+    alibabacloud.com/gpu-count: '2'
+    alibabacloud.com/gpu-milli: '2000'
+    cpu: 64
+    memory: 256000Mi
+    pods: '110'

--- a/example/pytorch-rl/node/pai-node-01.yaml
+++ b/example/pytorch-rl/node/pai-node-01.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Node
+metadata:
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: pai-node-01
+    kubernetes.io/os: linux
+    node-role.kubernetes.io/master: ''
+    alibabacloud.com/gpu-card-model: V100
+    node-ip: 192.168.0.101
+  name: pai-node-01
+status:
+  allocatable:
+    alibabacloud.com/gpu-count: "4"
+    alibabacloud.com/gpu-milli: "4000"
+    cpu: 64
+    memory: 256000Mi
+    pods: '110'
+  capacity:
+    alibabacloud.com/gpu-count: "4"
+    alibabacloud.com/gpu-milli: "4000"
+    cpu: 64
+    memory: 256000Mi
+    pods: '110'

--- a/example/pytorch-rl/pod/gpu-pod-00.yaml
+++ b/example/pytorch-rl/pod/gpu-pod-00.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod-00
+  namespace: pai-gpu
+  annotations:
+    alibabacloud.com/gpu-milli: "500"
+    alibabacloud.com/gpu-count: "1"
+spec:
+    containers:
+    - image: tensorflow:latest
+      name: main
+      resources:
+        limits:
+          cpu: 4
+          memory: 9216Mi
+        requests:
+          cpu: 4
+          memory: 9216Mi

--- a/example/pytorch-rl/pod/gpu-pod-01.yaml
+++ b/example/pytorch-rl/pod/gpu-pod-01.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod-01
+  namespace: pai-gpu
+spec:
+    containers:
+    - image: tensorflow:latest
+      name: main
+      resources:
+        limits:
+          cpu: 8
+          memory: 17408Mi
+        requests:
+          cpu: 8
+          memory: 17408Mi

--- a/example/pytorch-rl/pod/gpu-pod-02.yaml
+++ b/example/pytorch-rl/pod/gpu-pod-02.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod-02
+  namespace: pai-gpu
+  annotations:
+    alibabacloud.com/gpu-milli: "1000"
+    alibabacloud.com/gpu-count: "2"
+spec:
+    containers:
+    - image: tensorflow:latest
+      name: main
+      resources:
+        limits:
+          cpu: 12
+          memory: 18432Mi
+        requests:
+          cpu: 12
+          memory: 18432Mi

--- a/example/pytorch-rl/rl_service.py
+++ b/example/pytorch-rl/rl_service.py
@@ -1,0 +1,82 @@
+import argparse
+from flask import Flask, request, jsonify
+import torch
+import torch.nn as nn
+
+app = Flask(__name__)
+
+# Simple neural network policy
+class Policy(nn.Module):
+    def __init__(self, input_dim: int = 4):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, 16),
+            nn.ReLU(),
+            nn.Linear(16, 1)
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Output in scheduler score range 0-100
+        return torch.sigmoid(self.net(x)) * 100.0
+
+policy = Policy()
+
+# --- Resource parsing helpers -------------------------------------------------
+_CPU_M = 1000.0
+
+_MEM_UNITS = {
+    "Ki": 2 ** 10,
+    "Mi": 2 ** 20,
+    "Gi": 2 ** 30,
+    "Ti": 2 ** 40,
+}
+
+def parse_cpu(s: str) -> float:
+    if s.endswith("m"):
+        return float(s[:-1]) / _CPU_M
+    return float(s)
+
+def parse_mem(s: str) -> float:
+    for suf, mult in _MEM_UNITS.items():
+        if s.endswith(suf):
+            return float(s[:-len(suf)]) * mult
+    return float(s)
+
+# ----------------------------------------------------------------------------
+
+def build_features(pod: dict, node: dict) -> torch.Tensor:
+    cpu_req = 0.0
+    mem_req = 0.0
+    for c in pod.get("spec", {}).get("containers", []):
+        req = c.get("resources", {}).get("requests", {})
+        cpu_req += parse_cpu(req.get("cpu", "0"))
+        mem_req += parse_mem(req.get("memory", "0"))
+    alloc = node.get("status", {}).get("allocatable", {})
+    cpu_alloc = parse_cpu(alloc.get("cpu", "0"))
+    mem_alloc = parse_mem(alloc.get("memory", "0"))
+    return torch.tensor([cpu_alloc, mem_alloc, cpu_req, mem_req], dtype=torch.float32)
+
+@app.route('/score', methods=['POST'])
+def score():
+    payload = request.get_json(force=True)
+    pod = payload.get('pod', {})
+    nodes = payload.get('nodes', [])
+    result = {}
+    for node in nodes:
+        name = node.get('metadata', {}).get('name', '')
+        features = build_features(pod, node)
+        with torch.no_grad():
+            val = policy(features).item()
+        result[name] = int(val)
+    return jsonify({'scores': result})
+
+
+def main():
+    parser = argparse.ArgumentParser(description='RL scheduler service')
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', type=int, default=5000)
+    args = parser.parse_args()
+    app.run(host=args.host, port=args.port)
+
+if __name__ == '__main__':
+    main()

--- a/example/pytorch-rl/scheduler_config.yaml
+++ b/example/pytorch-rl/scheduler_config.yaml
@@ -1,0 +1,46 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+percentageOfNodesToScore: 100
+profiles:
+  - schedulerName: simon-scheduler
+    plugins:
+      filter:
+        enabled:
+          - name: Open-Gpu-Share
+      score:
+        disabled:
+          - name: RandomScore
+          - name: DotProductScore
+          - name: GpuClusteringScore
+          - name: GpuPackingScore
+          - name: BestFitScore
+          - name: FGDScore
+          - name: ImageLocality
+          - name: NodeAffinity
+          - name: PodTopologySpread
+          - name: TaintToleration
+          - name: NodeResourcesBalancedAllocation
+          - name: InterPodAffinity
+          - name: NodeResourcesLeastAllocated
+          - name: NodePreferAvoidPods
+        enabled:
+          - name: RLSchedulerScore
+            weight: 1000
+      reserve:
+        enabled:
+          - name: Open-Gpu-Share
+      bind:
+        disabled:
+          - name: DefaultBinder
+        enabled:
+          - name: Simon
+    pluginConfig:
+      - name: Open-Gpu-Share
+        args:
+          dimExtMethod: share
+          normMethod: max
+          gpuSelMethod: RLSchedulerScore
+      - name: RLSchedulerScore
+        args:
+          programPath: rl_service.py
+


### PR DESCRIPTION
## Summary
- add `example/pytorch-rl` directory with cluster and scheduler configs
- include sample `rl_service.py` and node/pod data for the PyTorch scheduler
- enable `RLSchedulerScore` plugin to score nodes via the RL service

## Testing
- `go test ./...`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68a3e38752b88327bb8de744f64563fb